### PR TITLE
manifests: make namespace names uniform

### DIFF
--- a/pkg/manifests/yaml/rte/namespace.yaml
+++ b/pkg/manifests/yaml/rte/namespace.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: rte
+  name: tas-topology-updater

--- a/pkg/manifests/yaml/sched/namespace.yaml
+++ b/pkg/manifests/yaml/sched/namespace.yaml
@@ -2,4 +2,4 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: test-namespace # Test namespace
+  name: tas-scheduler


### PR DESCRIPTION
Add a `tas-` prefix and make the namespace name more
descriptive.

Signed-off-by: Francesco Romani <fromani@redhat.com>