### PR TITLE
Fix the scheduler plugin manifests

### DIFF
--- a/pkg/manifests/yaml/sched/clusterrolebinding-vol-sched.yaml
+++ b/pkg/manifests/yaml/sched/clusterrolebinding-vol-sched.yaml
@@ -1,10 +1,10 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: my-scheduler-as-volume-scheduler
+  name: topo-aware-scheduler-as-volume-scheduler
 subjects:
 - kind: ServiceAccount
-  name: my-scheduler
+  name: topo-aware-scheduler
   namespace: kube-system
 roleRef:
   kind: ClusterRole

--- a/pkg/manifests/yaml/sched/deployment.yaml
+++ b/pkg/manifests/yaml/sched/deployment.yaml
@@ -19,9 +19,17 @@ spec:
         tier: control-plane
         version: second
     spec:
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       serviceAccountName: topo-aware-scheduler
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
       containers:
         - image: localhost:5000/scheduler-plugins/kube-scheduler:latest
           imagePullPolicy: Never

--- a/pkg/manifests/yaml/sched/deployment.yaml
+++ b/pkg/manifests/yaml/sched/deployment.yaml
@@ -34,6 +34,9 @@ spec:
           name: scheduler
           securityContext:
             privileged: false
+          resources:
+            requests:
+              cpu: 100m
           volumeMounts:
           - mountPath: /etc/kubernetes/scheduler.conf
             name: kubeconfig

--- a/pkg/manifests/yaml/sched/deployment.yaml
+++ b/pkg/manifests/yaml/sched/deployment.yaml
@@ -32,8 +32,6 @@ spec:
           - --authorization-kubeconfig=/etc/kubernetes/scheduler.conf
           - --config=/etc/kubernetes/scheduler-config/scheduler-config.yaml
           name: scheduler
-          securityContext:
-            privileged: false
           resources:
             requests:
               cpu: 100m
@@ -42,8 +40,6 @@ spec:
             name: kubeconfig
           - mountPath: /etc/kubernetes/scheduler-config
             name: topo-aware-scheduler-config-vol
-      hostNetwork: false
-      hostPID: false
       volumes:
       - hostPath:
           path: /etc/kubernetes/scheduler.conf

--- a/pkg/manifests/yaml/sched/deployment.yaml
+++ b/pkg/manifests/yaml/sched/deployment.yaml
@@ -32,7 +32,6 @@ spec:
         effect: NoSchedule
       containers:
         - image: localhost:5000/scheduler-plugins/kube-scheduler:latest
-          imagePullPolicy: Never
           command:
           - /bin/kube-scheduler
           - --scheduler-name=topo-aware-scheduler


### PR DESCRIPTION
Fix minor mistakes that found their way in the scheduler plugin manifests, and align to how the default kube scheduler behaves.