### PR TITLE
pkg: revamp logging

### DIFF
--- a/pkg/commands/deploy.go
+++ b/pkg/commands/deploy.go
@@ -17,12 +17,27 @@
 package commands
 
 import (
+	"log"
+
 	"github.com/fromanirh/deployer/pkg/deployer/api"
 	"github.com/fromanirh/deployer/pkg/deployer/rte"
 	"github.com/fromanirh/deployer/pkg/deployer/sched"
 
 	"github.com/spf13/cobra"
 )
+
+type logAdapter struct {
+	log      *log.Logger
+	debugLog *log.Logger
+}
+
+func (la logAdapter) Printf(format string, v ...interface{}) {
+	la.log.Printf(format, v...)
+}
+
+func (la logAdapter) Debugf(format string, v ...interface{}) {
+	la.debugLog.Printf(format, v...)
+}
 
 type deployOptions struct{}
 
@@ -48,13 +63,17 @@ func NewRemoveCommand(commonOpts *CommonOptions) *cobra.Command {
 		Use:   "remove",
 		Short: "remove the components and configurations needed for topology-aware-scheduling",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := sched.Remove(commonOpts.Log, sched.Options{}); err != nil {
+			la := logAdapter{
+				log:      commonOpts.Log,
+				debugLog: commonOpts.DebugLog,
+			}
+			if err := sched.Remove(la, sched.Options{}); err != nil {
 				return err
 			}
-			if err := rte.Remove(commonOpts.Log, rte.Options{}); err != nil {
+			if err := rte.Remove(la, rte.Options{}); err != nil {
 				return err
 			}
-			if err := api.Remove(commonOpts.Log, api.Options{}); err != nil {
+			if err := api.Remove(la, api.Options{}); err != nil {
 				return err
 			}
 			return nil
@@ -72,7 +91,11 @@ func NewDeployAPICommand(commonOpts *CommonOptions, opts *deployOptions) *cobra.
 		Use:   "api",
 		Short: "deploy the APIs needed for topology-aware-scheduling",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := api.Deploy(commonOpts.Log, api.Options{}); err != nil {
+			la := logAdapter{
+				log:      commonOpts.Log,
+				debugLog: commonOpts.DebugLog,
+			}
+			if err := api.Deploy(la, api.Options{}); err != nil {
 				return err
 			}
 			return nil
@@ -87,7 +110,11 @@ func NewDeploySchedulerPluginCommand(commonOpts *CommonOptions, opts *deployOpti
 		Use:   "scheduler-plugin",
 		Short: "deploy the scheduler plugin needed for topology-aware-scheduling",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return sched.Deploy(commonOpts.Log, sched.Options{})
+			la := logAdapter{
+				log:      commonOpts.Log,
+				debugLog: commonOpts.DebugLog,
+			}
+			return sched.Deploy(la, sched.Options{})
 		},
 		Args: cobra.NoArgs,
 	}
@@ -99,7 +126,11 @@ func NewDeployTopologyUpdaterCommand(commonOpts *CommonOptions, opts *deployOpti
 		Use:   "topology-updater",
 		Short: "deploy the topology updater needed for topology-aware-scheduling",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return rte.Deploy(commonOpts.Log, rte.Options{})
+			la := logAdapter{
+				log:      commonOpts.Log,
+				debugLog: commonOpts.DebugLog,
+			}
+			return rte.Deploy(la, rte.Options{})
 		},
 		Args: cobra.NoArgs,
 	}
@@ -111,7 +142,11 @@ func NewRemoveAPICommand(commonOpts *CommonOptions, opts *deployOptions) *cobra.
 		Use:   "api",
 		Short: "remove the APIs needed for topology-aware-scheduling",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := api.Remove(commonOpts.Log, api.Options{}); err != nil {
+			la := logAdapter{
+				log:      commonOpts.Log,
+				debugLog: commonOpts.DebugLog,
+			}
+			if err := api.Remove(la, api.Options{}); err != nil {
 				return err
 			}
 			return nil
@@ -126,7 +161,11 @@ func NewRemoveSchedulerPluginCommand(commonOpts *CommonOptions, opts *deployOpti
 		Use:   "scheduler-plugin",
 		Short: "remove the scheduler plugin needed for topology-aware-scheduling",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return sched.Remove(commonOpts.Log, sched.Options{})
+			la := logAdapter{
+				log:      commonOpts.Log,
+				debugLog: commonOpts.DebugLog,
+			}
+			return sched.Remove(la, sched.Options{})
 		},
 		Args: cobra.NoArgs,
 	}
@@ -138,7 +177,11 @@ func NewRemoveTopologyUpdaterCommand(commonOpts *CommonOptions, opts *deployOpti
 		Use:   "topology-updater",
 		Short: "remove the topology updater needed for topology-aware-scheduling",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return rte.Remove(commonOpts.Log, rte.Options{})
+			la := logAdapter{
+				log:      commonOpts.Log,
+				debugLog: commonOpts.DebugLog,
+			}
+			return rte.Remove(la, rte.Options{})
 		},
 		Args: cobra.NoArgs,
 	}
@@ -146,13 +189,17 @@ func NewRemoveTopologyUpdaterCommand(commonOpts *CommonOptions, opts *deployOpti
 }
 
 func deployOnCluster(commonOpts *CommonOptions, opts *deployOptions) error {
-	if err := api.Deploy(commonOpts.Log, api.Options{}); err != nil {
+	la := logAdapter{
+		log:      commonOpts.Log,
+		debugLog: commonOpts.DebugLog,
+	}
+	if err := api.Deploy(la, api.Options{}); err != nil {
 		return err
 	}
-	if err := rte.Deploy(commonOpts.Log, rte.Options{}); err != nil {
+	if err := rte.Deploy(la, rte.Options{}); err != nil {
 		return err
 	}
-	if err := sched.Deploy(commonOpts.Log, sched.Options{}); err != nil {
+	if err := sched.Deploy(la, sched.Options{}); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/commands/root.go
+++ b/pkg/commands/root.go
@@ -26,8 +26,9 @@ import (
 )
 
 type CommonOptions struct {
-	Debug bool
-	Log   *log.Logger
+	Debug    bool
+	Log      *log.Logger
+	DebugLog *log.Logger
 }
 
 func ShowHelp(cmd *cobra.Command, args []string) error {
@@ -47,10 +48,12 @@ func NewRootCommand(extraCmds ...NewCommandFunc) *cobra.Command {
 
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			if commonOpts.Debug {
-				commonOpts.Log = log.New(os.Stderr, "deployer ", log.LstdFlags)
+				commonOpts.DebugLog = log.New(os.Stderr, "", log.LstdFlags)
 			} else {
-				commonOpts.Log = log.New(ioutil.Discard, "", 0)
+				commonOpts.DebugLog = log.New(ioutil.Discard, "", 0)
 			}
+			// we abuse the logger to have a common interface and the timestamps
+			commonOpts.Log = log.New(os.Stdout, "", log.LstdFlags)
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/commands/validate.go
+++ b/pkg/commands/validate.go
@@ -57,7 +57,7 @@ func validateCluster(cmd *cobra.Command, commonOpts *CommonOptions, opts *valida
 	}
 
 	vd := validator.Validator{
-		Log: commonOpts.Log,
+		Log: commonOpts.DebugLog,
 	}
 	items, err := vd.ValidateClusterConfig(nodeList)
 	if err != nil {
@@ -68,6 +68,7 @@ func validateCluster(cmd *cobra.Command, commonOpts *CommonOptions, opts *valida
 	return nil
 }
 
+// we need undecorated output, so we need to use fmt.Printf here. log packages add no value.
 func printValidationResults(items []validator.ValidationResult, jsonOutput bool) {
 	if len(items) == 0 {
 		if jsonOutput {

--- a/pkg/deployer/api/api.go
+++ b/pkg/deployer/api/api.go
@@ -17,24 +17,23 @@
 package api
 
 import (
-	"log"
-
 	"github.com/fromanirh/deployer/pkg/deployer"
 	apimanifests "github.com/fromanirh/deployer/pkg/manifests/api"
 )
 
 type Options struct{}
 
-func Deploy(logger *log.Logger, opts Options) error {
+func Deploy(log deployer.Logger, opts Options) error {
 	var err error
+	log.Printf("deploying topology-aware-scheduling API...")
 
 	mf, err := apimanifests.GetManifests()
 	if err != nil {
 		return err
 	}
-	logger.Printf("  API manifests loaded")
+	log.Debugf("API manifests loaded")
 
-	hp, err := deployer.NewHelper("API")
+	hp, err := deployer.NewHelper("API", log)
 	if err != nil {
 		return err
 	}
@@ -43,19 +42,21 @@ func Deploy(logger *log.Logger, opts Options) error {
 		return err
 	}
 
+	log.Printf("...deployed topology-aware-scheduling API!")
 	return nil
 }
 
-func Remove(logger *log.Logger, opts Options) error {
+func Remove(log deployer.Logger, opts Options) error {
 	var err error
+	log.Printf("removing topology-aware-scheduling API...")
 
 	mf, err := apimanifests.GetManifests()
 	if err != nil {
 		return err
 	}
-	logger.Printf("  API manifests loaded")
+	log.Debugf("API manifests loaded")
 
-	hp, err := deployer.NewHelper("API")
+	hp, err := deployer.NewHelper("API", log)
 	if err != nil {
 		return err
 	}
@@ -64,5 +65,6 @@ func Remove(logger *log.Logger, opts Options) error {
 		return err
 	}
 
+	log.Printf("...removed topology-aware-scheduling API!")
 	return nil
 }

--- a/pkg/deployer/deployer.go
+++ b/pkg/deployer/deployer.go
@@ -18,7 +18,7 @@ package deployer
 
 import (
 	"context"
-	"fmt"
+	"log"
 	"time"
 
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -27,12 +27,18 @@ import (
 	"github.com/fromanirh/deployer/pkg/clientutil"
 )
 
+type Logger interface {
+	Printf(format string, v ...interface{})
+	Debugf(format string, v ...interface{})
+}
+
 type Helper struct {
 	tag string
 	cli client.Client
+	log Logger
 }
 
-func NewHelper(tag string) (*Helper, error) {
+func NewHelper(tag string, log Logger) (*Helper, error) {
 	cli, err := clientutil.New()
 	if err != nil {
 		return nil, err
@@ -40,26 +46,27 @@ func NewHelper(tag string) (*Helper, error) {
 	return &Helper{
 		tag: tag,
 		cli: cli,
+		log: log,
 	}, nil
 }
 
 func (hp *Helper) CreateObject(obj client.Object) error {
 	objKind := obj.GetObjectKind().GroupVersionKind().Kind // shortcut
 	if err := hp.cli.Create(context.TODO(), obj); err != nil {
-		fmt.Printf("-%5s> error creating %s %q: %v\n", hp.tag, objKind, obj.GetName(), err)
+		log.Printf("-%5s> error creating %s %q: %v", hp.tag, objKind, obj.GetName(), err)
 		return err
 	}
-	fmt.Printf("-%5s> created %s %q\n", hp.tag, objKind, obj.GetName())
+	log.Printf("-%5s> created %s %q", hp.tag, objKind, obj.GetName())
 	return nil
 }
 
 func (hp *Helper) DeleteObject(obj client.Object) error {
 	objKind := obj.GetObjectKind().GroupVersionKind().Kind // shortcut
 	if err := hp.cli.Delete(context.TODO(), obj); err != nil {
-		fmt.Printf("-%5s> error deleting %s %q: %v\n", hp.tag, objKind, obj.GetName(), err)
+		log.Printf("-%5s> error deleting %s %q: %v", hp.tag, objKind, obj.GetName(), err)
 		return err
 	}
-	fmt.Printf("-%5s> deleted %s %q\n", hp.tag, objKind, obj.GetName())
+	log.Printf("-%5s> deleted %s %q", hp.tag, objKind, obj.GetName())
 	return nil
 }
 

--- a/pkg/deployer/rte/rte.go
+++ b/pkg/deployer/rte/rte.go
@@ -17,8 +17,6 @@
 package rte
 
 import (
-	"log"
-
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -28,17 +26,18 @@ import (
 
 type Options struct{}
 
-func Deploy(logger *log.Logger, opts Options) error {
+func Deploy(log deployer.Logger, opts Options) error {
 	var err error
+	log.Printf("deploying topology-aware-scheduling topology updater...")
 
 	mf, err := rtemanifests.GetManifests()
 	if err != nil {
 		return err
 	}
 	mf = mf.UpdateNamespace().UpdatePullspecs()
-	logger.Printf("  RTE manifests loaded")
+	log.Debugf("RTE manifests loaded")
 
-	hp, err := deployer.NewHelper("RTE")
+	hp, err := deployer.NewHelper("RTE", log)
 	if err != nil {
 		return err
 	}
@@ -58,13 +57,15 @@ func Deploy(logger *log.Logger, opts Options) error {
 		return err
 	}
 
+	log.Printf("...deployed topology-aware-scheduling topology updater!")
 	return nil
 }
 
-func Remove(logger *log.Logger, opts Options) error {
+func Remove(log deployer.Logger, opts Options) error {
 	var err error
+	log.Printf("removing topology-aware-scheduling topology updater...")
 
-	hp, err := deployer.NewHelper("RTE")
+	hp, err := deployer.NewHelper("RTE", log)
 	if err != nil {
 		return err
 	}
@@ -74,7 +75,7 @@ func Remove(logger *log.Logger, opts Options) error {
 		return err
 	}
 	mf = mf.UpdateNamespace()
-	logger.Printf("  RTE manifests loaded")
+	log.Debugf("RTE manifests loaded")
 
 	// since we created everything in the namespace, we can just do
 	if err := hp.DeleteObject(mf.Namespace); err != nil {
@@ -91,5 +92,6 @@ func Remove(logger *log.Logger, opts Options) error {
 		return err
 	}
 
+	log.Printf("...removed topology-aware-scheduling topology updater!")
 	return nil
 }

--- a/pkg/deployer/sched/sched.go
+++ b/pkg/deployer/sched/sched.go
@@ -17,8 +17,6 @@
 package sched
 
 import (
-	"log"
-
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -29,8 +27,9 @@ import (
 
 type Options struct{}
 
-func Deploy(logger *log.Logger, opts Options) error {
+func Deploy(log deployer.Logger, opts Options) error {
 	var err error
+	log.Printf("deploying topology-aware-scheduling scheduler plugin...")
 
 	mf, err := schedmanifests.GetManifests()
 	if err != nil {
@@ -38,9 +37,9 @@ func Deploy(logger *log.Logger, opts Options) error {
 	}
 
 	mf = mf.UpdateNamespace().UpdatePullspecs()
-	logger.Printf("SCHED manifests loaded")
+	log.Debugf("SCD manifests loaded")
 
-	hp, err := deployer.NewHelper("SCHED")
+	hp, err := deployer.NewHelper("SCD", log)
 	if err != nil {
 		return err
 	}
@@ -51,11 +50,13 @@ func Deploy(logger *log.Logger, opts Options) error {
 		}
 	}
 
+	log.Printf("...deployed topology-aware-scheduling scheduler plugin!")
 	return nil
 }
 
-func Remove(logger *log.Logger, opts Options) error {
+func Remove(log deployer.Logger, opts Options) error {
 	var err error
+	log.Printf("removing topology-aware-scheduling scheduler plugin...")
 
 	mf, err := schedmanifests.GetManifests()
 	if err != nil {
@@ -63,9 +64,9 @@ func Remove(logger *log.Logger, opts Options) error {
 	}
 
 	mf = mf.UpdateNamespace()
-	logger.Printf("SCHED manifests loaded")
+	log.Debugf("SCD manifests loaded")
 
-	hp, err := deployer.NewHelper("SCHED")
+	hp, err := deployer.NewHelper("SCD", log)
 	if err != nil {
 		return err
 	}
@@ -98,5 +99,7 @@ func Remove(logger *log.Logger, opts Options) error {
 	if err = hp.DeleteObject(mf.ClusterRole); err != nil {
 		return err
 	}
+
+	log.Printf("...removed topology-aware-scheduling scheduler plugin!")
 	return nil
 }


### PR DESCRIPTION
We need only two level of logging
- regular status messages
- debug messages (for troubleshooting)

So we build a minimal abstraction on top of the stdlib's `log`
package.

It's important to keep the distinction between logging and output.
The former is about status messages, which are useful to track
the program flow, and which are most used to track progress or
to understand what went wrong.
The latter is about the expected output from a program.

In our case:
- deploy/remove has logging, not output.
- render has output, may have logging (in the future)
- validate has logging and output

We should never mix logging and output on the same destination
(e.g on stdout)

Signed-off-by: Francesco Romani <fromani@redhat.com>