### PR TITLE
images: add a way to override the image

### DIFF
--- a/pkg/images/images.go
+++ b/pkg/images/images.go
@@ -16,7 +16,18 @@
 
 package images
 
-const (
-	SchedulerPluginDefaultImage          = "k8s.gcr.io/scheduler-plugins/kube-scheduler:v0.19.9"
-	ResourceTopologyExporterDefaultImage = "quay.io/openshift-kni/resource-topology-exporter:4.9-snapshot"
+import "os"
+
+func init() {
+	if schedImage, ok := os.LookupEnv("TAS_SCHEDULER_PLUGIN_IMAGE"); ok {
+		SchedulerPluginImage = schedImage
+	}
+	if rteImage, ok := os.LookupEnv("TAS_RESOURCE_EXPORTER_IMAGE"); ok {
+		ResourceTopologyExporterImage = rteImage
+	}
+}
+
+var (
+	SchedulerPluginImage          = SchedulerPluginDefaultImage
+	ResourceTopologyExporterImage = ResourceTopologyExporterDefaultImage
 )


### PR DESCRIPTION
Add env variables to be able to override images without
recompiling. This is meant to be a very sporadic action,
so we kept the option half-hidden using env variables.
Should this turn to be more used than we anticipate, we will
revisit and promote to full blown options.

Signed-off-by: Francesco Romani <fromani@redhat.com>