### PR TITLE
Render subcommands

### DIFF
--- a/pkg/commands/deploy.go
+++ b/pkg/commands/deploy.go
@@ -71,17 +71,25 @@ func NewRemoveCommand(commonOpts *CommonOptions) *cobra.Command {
 				debugLog: commonOpts.DebugLog,
 			}
 			var err error
-			err = sched.Remove(la, sched.Options{WaitCompletion: opts.waitCompletion})
+			err = sched.Remove(la, sched.Options{
+				Platform:       commonOpts.Platform,
+				WaitCompletion: opts.waitCompletion,
+			})
 			if err != nil {
 				// intentionally keep going to remove as much as possible
 				log.Printf("error removing: %v", err)
 			}
-			err = rte.Remove(la, rte.Options{WaitCompletion: opts.waitCompletion})
+			err = rte.Remove(la, rte.Options{
+				Platform:       commonOpts.Platform,
+				WaitCompletion: opts.waitCompletion,
+			})
 			if err != nil {
 				// intentionally keep going to remove as much as possible
 				log.Printf("error removing: %v", err)
 			}
-			err = api.Remove(la, api.Options{})
+			err = api.Remove(la, api.Options{
+				Platform: commonOpts.Platform,
+			})
 			if err != nil {
 				// intentionally keep going to remove as much as possible
 				log.Printf("error removing: %v", err)
@@ -106,7 +114,7 @@ func NewDeployAPICommand(commonOpts *CommonOptions, opts *deployOptions) *cobra.
 				log:      commonOpts.Log,
 				debugLog: commonOpts.DebugLog,
 			}
-			if err := api.Deploy(la, api.Options{}); err != nil {
+			if err := api.Deploy(la, api.Options{Platform: commonOpts.Platform}); err != nil {
 				return err
 			}
 			return nil
@@ -125,7 +133,10 @@ func NewDeploySchedulerPluginCommand(commonOpts *CommonOptions, opts *deployOpti
 				log:      commonOpts.Log,
 				debugLog: commonOpts.DebugLog,
 			}
-			return sched.Deploy(la, sched.Options{WaitCompletion: opts.waitCompletion})
+			return sched.Deploy(la, sched.Options{
+				Platform:       commonOpts.Platform,
+				WaitCompletion: opts.waitCompletion,
+			})
 		},
 		Args: cobra.NoArgs,
 	}
@@ -141,7 +152,10 @@ func NewDeployTopologyUpdaterCommand(commonOpts *CommonOptions, opts *deployOpti
 				log:      commonOpts.Log,
 				debugLog: commonOpts.DebugLog,
 			}
-			return rte.Deploy(la, rte.Options{WaitCompletion: opts.waitCompletion})
+			return rte.Deploy(la, rte.Options{
+				Platform:       commonOpts.Platform,
+				WaitCompletion: opts.waitCompletion,
+			})
 		},
 		Args: cobra.NoArgs,
 	}
@@ -157,7 +171,7 @@ func NewRemoveAPICommand(commonOpts *CommonOptions, opts *deployOptions) *cobra.
 				log:      commonOpts.Log,
 				debugLog: commonOpts.DebugLog,
 			}
-			if err := api.Remove(la, api.Options{}); err != nil {
+			if err := api.Remove(la, api.Options{Platform: commonOpts.Platform}); err != nil {
 				return err
 			}
 			return nil
@@ -176,7 +190,10 @@ func NewRemoveSchedulerPluginCommand(commonOpts *CommonOptions, opts *deployOpti
 				log:      commonOpts.Log,
 				debugLog: commonOpts.DebugLog,
 			}
-			return sched.Remove(la, sched.Options{WaitCompletion: opts.waitCompletion})
+			return sched.Remove(la, sched.Options{
+				Platform:       commonOpts.Platform,
+				WaitCompletion: opts.waitCompletion,
+			})
 		},
 		Args: cobra.NoArgs,
 	}
@@ -192,7 +209,10 @@ func NewRemoveTopologyUpdaterCommand(commonOpts *CommonOptions, opts *deployOpti
 				log:      commonOpts.Log,
 				debugLog: commonOpts.DebugLog,
 			}
-			return rte.Remove(la, rte.Options{WaitCompletion: opts.waitCompletion})
+			return rte.Remove(la, rte.Options{
+				Platform:       commonOpts.Platform,
+				WaitCompletion: opts.waitCompletion,
+			})
 		},
 		Args: cobra.NoArgs,
 	}
@@ -204,13 +224,21 @@ func deployOnCluster(commonOpts *CommonOptions, opts *deployOptions) error {
 		log:      commonOpts.Log,
 		debugLog: commonOpts.DebugLog,
 	}
-	if err := api.Deploy(la, api.Options{}); err != nil {
+	if err := api.Deploy(la, api.Options{
+		Platform: commonOpts.Platform,
+	}); err != nil {
 		return err
 	}
-	if err := rte.Deploy(la, rte.Options{WaitCompletion: opts.waitCompletion}); err != nil {
+	if err := rte.Deploy(la, rte.Options{
+		Platform:       commonOpts.Platform,
+		WaitCompletion: opts.waitCompletion,
+	}); err != nil {
 		return err
 	}
-	if err := sched.Deploy(la, sched.Options{WaitCompletion: opts.waitCompletion}); err != nil {
+	if err := sched.Deploy(la, sched.Options{
+		Platform:       commonOpts.Platform,
+		WaitCompletion: opts.waitCompletion,
+	}); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/commands/render.go
+++ b/pkg/commands/render.go
@@ -47,19 +47,19 @@ func NewRenderCommand(commonOpts *CommonOptions) *cobra.Command {
 func renderManifests(cmd *cobra.Command, commonOpts *CommonOptions, opts *renderOptions, args []string) error {
 	var objs []client.Object
 
-	apiManifests, err := api.GetManifests()
+	apiManifests, err := api.GetManifests(commonOpts.Platform)
 	if err != nil {
 		return err
 	}
 	objs = append(objs, apiManifests.UpdateNamespace().UpdatePullspecs().ToObjects()...)
 
-	rteManifests, err := rte.GetManifests()
+	rteManifests, err := rte.GetManifests(commonOpts.Platform)
 	if err != nil {
 		return err
 	}
 	objs = append(objs, rteManifests.UpdateNamespace().UpdatePullspecs().ToObjects()...)
 
-	schedManifests, err := sched.GetManifests()
+	schedManifests, err := sched.GetManifests(commonOpts.Platform)
 	if err != nil {
 		return err
 	}

--- a/pkg/commands/render.go
+++ b/pkg/commands/render.go
@@ -41,6 +41,57 @@ func NewRenderCommand(commonOpts *CommonOptions) *cobra.Command {
 		},
 		Args: cobra.NoArgs,
 	}
+	render.AddCommand(NewRenderAPICommand(commonOpts, opts))
+	render.AddCommand(NewRenderSchedulerPluginCommand(commonOpts, opts))
+	render.AddCommand(NewRenderTopologyUpdaterCommand(commonOpts, opts))
+	return render
+}
+
+func NewRenderAPICommand(commonOpts *CommonOptions, opts *renderOptions) *cobra.Command {
+	render := &cobra.Command{
+		Use:   "api",
+		Short: "render the APIs needed for topology-aware-scheduling",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			apiManifests, err := api.GetManifests(commonOpts.Platform)
+			if err != nil {
+				return err
+			}
+			return renderObjects(apiManifests.UpdateNamespace().UpdatePullspecs().ToObjects())
+		},
+		Args: cobra.NoArgs,
+	}
+	return render
+}
+
+func NewRenderSchedulerPluginCommand(commonOpts *CommonOptions, opts *renderOptions) *cobra.Command {
+	render := &cobra.Command{
+		Use:   "scheduler-plugin",
+		Short: "render the scheduler plugin needed for topology-aware-scheduling",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			schedManifests, err := sched.GetManifests(commonOpts.Platform)
+			if err != nil {
+				return err
+			}
+			return renderObjects(schedManifests.UpdateNamespace().UpdatePullspecs().ToObjects())
+		},
+		Args: cobra.NoArgs,
+	}
+	return render
+}
+
+func NewRenderTopologyUpdaterCommand(commonOpts *CommonOptions, opts *renderOptions) *cobra.Command {
+	render := &cobra.Command{
+		Use:   "topology-updater",
+		Short: "render the topology updater needed for topology-aware-scheduling",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			rteManifests, err := rte.GetManifests(commonOpts.Platform)
+			if err != nil {
+				return err
+			}
+			return renderObjects(rteManifests.UpdateNamespace().UpdatePullspecs().ToObjects())
+		},
+		Args: cobra.NoArgs,
+	}
 	return render
 }
 
@@ -65,6 +116,10 @@ func renderManifests(cmd *cobra.Command, commonOpts *CommonOptions, opts *render
 	}
 	objs = append(objs, schedManifests.UpdateNamespace().UpdatePullspecs().ToObjects()...)
 
+	return renderObjects(objs)
+}
+
+func renderObjects(objs []client.Object) error {
 	for _, obj := range objs {
 		fmt.Printf("---\n")
 		if err := manifests.SerializeObject(obj, os.Stdout); err != nil {

--- a/pkg/commands/root.go
+++ b/pkg/commands/root.go
@@ -22,13 +22,16 @@ import (
 	"log"
 	"os"
 
+	"github.com/fromanirh/deployer/pkg/deployer/platform"
 	"github.com/spf13/cobra"
 )
 
 type CommonOptions struct {
 	Debug    bool
+	Platform platform.Platform
 	Log      *log.Logger
 	DebugLog *log.Logger
+	plat     string
 }
 
 func ShowHelp(cmd *cobra.Command, args []string) error {
@@ -54,6 +57,11 @@ func NewRootCommand(extraCmds ...NewCommandFunc) *cobra.Command {
 			}
 			// we abuse the logger to have a common interface and the timestamps
 			commonOpts.Log = log.New(os.Stdout, "", log.LstdFlags)
+			var ok bool
+			commonOpts.Platform, ok = platform.FromString(commonOpts.plat)
+			if !ok {
+				return fmt.Errorf("unknown platform: %q", commonOpts.plat)
+			}
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -64,6 +72,7 @@ func NewRootCommand(extraCmds ...NewCommandFunc) *cobra.Command {
 	}
 
 	root.PersistentFlags().BoolVarP(&commonOpts.Debug, "debug", "D", false, "enable debug log")
+	root.PersistentFlags().StringVarP(&commonOpts.plat, "platform", "P", "kubernetes", "platform to deploy on")
 
 	root.AddCommand(
 		NewRenderCommand(commonOpts),

--- a/pkg/deployer/api/api.go
+++ b/pkg/deployer/api/api.go
@@ -18,16 +18,19 @@ package api
 
 import (
 	"github.com/fromanirh/deployer/pkg/deployer"
+	"github.com/fromanirh/deployer/pkg/deployer/platform"
 	apimanifests "github.com/fromanirh/deployer/pkg/manifests/api"
 )
 
-type Options struct{}
+type Options struct {
+	Platform platform.Platform
+}
 
 func Deploy(log deployer.Logger, opts Options) error {
 	var err error
 	log.Printf("deploying topology-aware-scheduling API...")
 
-	mf, err := apimanifests.GetManifests()
+	mf, err := apimanifests.GetManifests(opts.Platform)
 	if err != nil {
 		return err
 	}
@@ -50,7 +53,7 @@ func Remove(log deployer.Logger, opts Options) error {
 	var err error
 	log.Printf("removing topology-aware-scheduling API...")
 
-	mf, err := apimanifests.GetManifests()
+	mf, err := apimanifests.GetManifests(opts.Platform)
 	if err != nil {
 		return err
 	}

--- a/pkg/deployer/platform/platform.go
+++ b/pkg/deployer/platform/platform.go
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2021 Red Hat, Inc.
+ */
+
+package platform
+
+import "strings"
+
+type Platform string
+
+const (
+	Unknown    = Platform("Unknown")
+	Kubernetes = Platform("Kubernetes")
+	OpenShift  = Platform("OpenShift")
+)
+
+func (p Platform) String() string {
+	return string(p)
+}
+
+func FromString(plat string) (Platform, bool) {
+	plat = strings.ToLower(plat)
+	switch plat {
+	case "kubernetes":
+		return Kubernetes, true
+	case "openshift":
+		return OpenShift, true
+	default:
+		return Unknown, false
+	}
+}

--- a/pkg/deployer/rte/rte.go
+++ b/pkg/deployer/rte/rte.go
@@ -18,10 +18,12 @@ package rte
 
 import (
 	"github.com/fromanirh/deployer/pkg/deployer"
+	"github.com/fromanirh/deployer/pkg/deployer/platform"
 	rtemanifests "github.com/fromanirh/deployer/pkg/manifests/rte"
 )
 
 type Options struct {
+	Platform       platform.Platform
 	WaitCompletion bool
 }
 
@@ -29,7 +31,7 @@ func Deploy(log deployer.Logger, opts Options) error {
 	var err error
 	log.Printf("deploying topology-aware-scheduling topology updater...")
 
-	mf, err := rtemanifests.GetManifests()
+	mf, err := rtemanifests.GetManifests(opts.Platform)
 	if err != nil {
 		return err
 	}
@@ -66,7 +68,7 @@ func Remove(log deployer.Logger, opts Options) error {
 		return err
 	}
 
-	mf, err := rtemanifests.GetManifests()
+	mf, err := rtemanifests.GetManifests(opts.Platform)
 	if err != nil {
 		return err
 	}

--- a/pkg/deployer/sched/sched.go
+++ b/pkg/deployer/sched/sched.go
@@ -18,10 +18,12 @@ package sched
 
 import (
 	"github.com/fromanirh/deployer/pkg/deployer"
+	"github.com/fromanirh/deployer/pkg/deployer/platform"
 	schedmanifests "github.com/fromanirh/deployer/pkg/manifests/sched"
 )
 
 type Options struct {
+	Platform       platform.Platform
 	WaitCompletion bool
 }
 
@@ -29,7 +31,7 @@ func Deploy(log deployer.Logger, opts Options) error {
 	var err error
 	log.Printf("deploying topology-aware-scheduling scheduler plugin...")
 
-	mf, err := schedmanifests.GetManifests()
+	mf, err := schedmanifests.GetManifests(opts.Platform)
 	if err != nil {
 		return err
 	}
@@ -62,7 +64,7 @@ func Remove(log deployer.Logger, opts Options) error {
 	var err error
 	log.Printf("removing topology-aware-scheduling scheduler plugin...")
 
-	mf, err := schedmanifests.GetManifests()
+	mf, err := schedmanifests.GetManifests(opts.Platform)
 	if err != nil {
 		return err
 	}

--- a/pkg/manifests/api/api.go
+++ b/pkg/manifests/api/api.go
@@ -22,11 +22,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/fromanirh/deployer/pkg/deployer"
+	"github.com/fromanirh/deployer/pkg/deployer/platform"
 	"github.com/fromanirh/deployer/pkg/manifests"
 )
 
 type Manifests struct {
-	Crd *apiextensionv1.CustomResourceDefinition
+	Crd  *apiextensionv1.CustomResourceDefinition
+	plat platform.Platform
 }
 
 func (mf Manifests) ToObjects() []client.Object {
@@ -65,9 +67,11 @@ func (mf Manifests) UpdatePullspecs() Manifests {
 	return ret
 }
 
-func GetManifests() (Manifests, error) {
+func GetManifests(plat platform.Platform) (Manifests, error) {
 	var err error
-	mf := Manifests{}
+	mf := Manifests{
+		plat: plat,
+	}
 
 	mf.Crd, err = manifests.APICRD()
 	if err != nil {

--- a/pkg/manifests/rte/rte.go
+++ b/pkg/manifests/rte/rte.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/fromanirh/deployer/pkg/deployer"
+	"github.com/fromanirh/deployer/pkg/deployer/platform"
 	"github.com/fromanirh/deployer/pkg/deployer/wait"
 	"github.com/fromanirh/deployer/pkg/manifests"
 )
@@ -34,6 +35,7 @@ type Manifests struct {
 	ClusterRole        *rbacv1.ClusterRole
 	ClusterRoleBinding *rbacv1.ClusterRoleBinding
 	DaemonSet          *appsv1.DaemonSet
+	plat               platform.Platform
 }
 
 func (mf Manifests) Clone() Manifests {
@@ -98,9 +100,11 @@ func (mf Manifests) ToDeletableObjects(hp *deployer.Helper, log deployer.Logger)
 	}
 }
 
-func GetManifests() (Manifests, error) {
+func GetManifests(plat platform.Platform) (Manifests, error) {
 	var err error
-	mf := Manifests{}
+	mf := Manifests{
+		plat: plat,
+	}
 	mf.Namespace, err = manifests.Namespace(manifests.ComponentResourceTopologyExporter)
 	if err != nil {
 		return mf, err

--- a/pkg/manifests/sched/sched.go
+++ b/pkg/manifests/sched/sched.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/fromanirh/deployer/pkg/deployer"
+	"github.com/fromanirh/deployer/pkg/deployer/platform"
 	"github.com/fromanirh/deployer/pkg/deployer/wait"
 	"github.com/fromanirh/deployer/pkg/manifests"
 )
@@ -37,6 +38,7 @@ type Manifests struct {
 	RoleBinding             *rbacv1.RoleBinding
 	ConfigMap               *corev1.ConfigMap
 	Deployment              *appsv1.Deployment
+	plat                    platform.Platform
 }
 
 func (mf Manifests) Clone() Manifests {
@@ -109,9 +111,11 @@ func (mf Manifests) ToDeletableObjects(hp *deployer.Helper, log deployer.Logger)
 	}
 }
 
-func GetManifests() (Manifests, error) {
+func GetManifests(plat platform.Platform) (Manifests, error) {
 	var err error
-	mf := Manifests{}
+	mf := Manifests{
+		plat: plat,
+	}
 	mf.ServiceAccount, err = manifests.ServiceAccount(manifests.ComponentSchedulerPlugin)
 	if err != nil {
 		return mf, err

--- a/test/e2e/positive.go
+++ b/test/e2e/positive.go
@@ -37,6 +37,7 @@ import (
 
 	"github.com/fromanirh/deployer/pkg/clientutil"
 	"github.com/fromanirh/deployer/pkg/clientutil/nodes"
+	"github.com/fromanirh/deployer/pkg/deployer/platform"
 	"github.com/fromanirh/deployer/pkg/manifests/rte"
 	"github.com/fromanirh/deployer/pkg/manifests/sched"
 )
@@ -113,13 +114,13 @@ var _ = ginkgo.Describe("[PositiveFlow] Deployer execution", func() {
 
 		ginkgo.It("should perform overall deployment and verify all pods are running", func() {
 			ginkgo.By("checking that resource-topology-exporter pod is running")
-			mf, err := rte.GetManifests()
+			mf, err := rte.GetManifests(platform.Kubernetes)
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 			mf = mf.UpdateNamespace()
 			waitPodsToBeRunningByRegex(fmt.Sprintf("%s-*", mf.DaemonSet.Name))
 
 			ginkgo.By("checking that topo-aware-scheduler pod is running")
-			mfs, err := sched.GetManifests()
+			mfs, err := sched.GetManifests(platform.Kubernetes)
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 			mfs = mfs.UpdateNamespace()
 			waitPodsToBeRunningByRegex(fmt.Sprintf("%s-*", mfs.Deployment.Name))


### PR DESCRIPTION
Much like we already do with `deploy` and `remove` subcommands, we add support to only partially render the manifests.
