### PR TITLE
topology-updater: add support to deploy on OCP

### DIFF
--- a/pkg/commands/render.go
+++ b/pkg/commands/render.go
@@ -56,7 +56,7 @@ func NewRenderAPICommand(commonOpts *CommonOptions, opts *renderOptions) *cobra.
 			if err != nil {
 				return err
 			}
-			return renderObjects(apiManifests.UpdateNamespace().UpdatePullspecs().ToObjects())
+			return renderObjects(apiManifests.Update().ToObjects())
 		},
 		Args: cobra.NoArgs,
 	}
@@ -72,7 +72,7 @@ func NewRenderSchedulerPluginCommand(commonOpts *CommonOptions, opts *renderOpti
 			if err != nil {
 				return err
 			}
-			return renderObjects(schedManifests.UpdateNamespace().UpdatePullspecs().ToObjects())
+			return renderObjects(schedManifests.Update().ToObjects())
 		},
 		Args: cobra.NoArgs,
 	}
@@ -88,7 +88,7 @@ func NewRenderTopologyUpdaterCommand(commonOpts *CommonOptions, opts *renderOpti
 			if err != nil {
 				return err
 			}
-			return renderObjects(rteManifests.UpdateNamespace().UpdatePullspecs().ToObjects())
+			return renderObjects(rteManifests.Update().ToObjects())
 		},
 		Args: cobra.NoArgs,
 	}
@@ -102,19 +102,19 @@ func renderManifests(cmd *cobra.Command, commonOpts *CommonOptions, opts *render
 	if err != nil {
 		return err
 	}
-	objs = append(objs, apiManifests.UpdateNamespace().UpdatePullspecs().ToObjects()...)
+	objs = append(objs, apiManifests.Update().ToObjects()...)
 
 	rteManifests, err := rte.GetManifests(commonOpts.Platform)
 	if err != nil {
 		return err
 	}
-	objs = append(objs, rteManifests.UpdateNamespace().UpdatePullspecs().ToObjects()...)
+	objs = append(objs, rteManifests.Update().ToObjects()...)
 
 	schedManifests, err := sched.GetManifests(commonOpts.Platform)
 	if err != nil {
 		return err
 	}
-	objs = append(objs, schedManifests.UpdateNamespace().UpdatePullspecs().ToObjects()...)
+	objs = append(objs, schedManifests.Update().ToObjects()...)
 
 	return renderObjects(objs)
 }

--- a/pkg/deployer/rte/rte.go
+++ b/pkg/deployer/rte/rte.go
@@ -35,7 +35,7 @@ func Deploy(log deployer.Logger, opts Options) error {
 	if err != nil {
 		return err
 	}
-	mf = mf.UpdateNamespace().UpdatePullspecs()
+	mf = mf.Update()
 	log.Debugf("RTE manifests loaded")
 
 	hp, err := deployer.NewHelper("RTE", log)
@@ -72,7 +72,7 @@ func Remove(log deployer.Logger, opts Options) error {
 	if err != nil {
 		return err
 	}
-	mf = mf.UpdateNamespace()
+	mf = mf.Update()
 	log.Debugf("RTE manifests loaded")
 
 	for _, wo := range mf.ToDeletableObjects(hp, log) {

--- a/pkg/deployer/sched/sched.go
+++ b/pkg/deployer/sched/sched.go
@@ -36,7 +36,7 @@ func Deploy(log deployer.Logger, opts Options) error {
 		return err
 	}
 
-	mf = mf.UpdateNamespace().UpdatePullspecs()
+	mf = mf.Update()
 	log.Debugf("SCD manifests loaded")
 
 	hp, err := deployer.NewHelper("SCD", log)
@@ -69,7 +69,7 @@ func Remove(log deployer.Logger, opts Options) error {
 		return err
 	}
 
-	mf = mf.UpdateNamespace()
+	mf = mf.Update()
 	log.Debugf("SCD manifests loaded")
 
 	hp, err := deployer.NewHelper("SCD", log)

--- a/pkg/manifests/api/api.go
+++ b/pkg/manifests/api/api.go
@@ -55,13 +55,7 @@ func (mf Manifests) Clone() Manifests {
 	}
 }
 
-func (mf Manifests) UpdateNamespace() Manifests {
-	ret := mf.Clone()
-	// nothing to do atm
-	return ret
-}
-
-func (mf Manifests) UpdatePullspecs() Manifests {
+func (mf Manifests) Update() Manifests {
 	ret := mf.Clone()
 	// nothing to do atm
 	return ret

--- a/pkg/manifests/sched/sched.go
+++ b/pkg/manifests/sched/sched.go
@@ -54,13 +54,7 @@ func (mf Manifests) Clone() Manifests {
 	}
 }
 
-func (mf Manifests) UpdateNamespace() Manifests {
-	ret := mf.Clone()
-	// nothing to do here
-	return ret
-}
-
-func (mf Manifests) UpdatePullspecs() Manifests {
+func (mf Manifests) Update() Manifests {
 	ret := mf.Clone()
 	ret.Deployment = manifests.UpdateSchedulerPluginDeployment(ret.Deployment)
 	return ret

--- a/pkg/manifests/updates.go
+++ b/pkg/manifests/updates.go
@@ -2,9 +2,11 @@ package manifests
 
 import (
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 
 	"github.com/drone/envsubst"
 
+	"github.com/fromanirh/deployer/pkg/deployer/platform"
 	"github.com/fromanirh/deployer/pkg/images"
 )
 
@@ -14,18 +16,27 @@ func UpdateSchedulerPluginDeployment(dp *appsv1.Deployment) *appsv1.Deployment {
 	return ret
 }
 
-func UpdateResourceTopologyExporterDaemonSet(ds *appsv1.DaemonSet) *appsv1.DaemonSet {
+func UpdateResourceTopologyExporterDaemonSet(ds *appsv1.DaemonSet, plat platform.Platform) *appsv1.DaemonSet {
 	ret := ds.DeepCopy()
 	// TODO: better match by name than assume container#0 is RTE proper (not minion)
 	ret.Spec.Template.Spec.Containers[0].Image = images.ResourceTopologyExporterImage
-	ret.Spec.Template.Spec.Containers[0].Command = UpdateResourceTopologyExporterCommand(ds.Spec.Template.Spec.Containers[0].Command)
+	vars := map[string]string{
+		"RTE_POLL_INTERVAL": "10s",
+		"EXPORT_NAMESPACE":  ds.Namespace,
+	}
+	ret.Spec.Template.Spec.Containers[0].Command = UpdateResourceTopologyExporterCommand(ds.Spec.Template.Spec.Containers[0].Command, vars, plat)
+	if plat == platform.OpenShift {
+		// this is needed to put watches in the kubelet state dirs AND
+		// to open the podresources socket in R/W mode
+		if ret.Spec.Template.Spec.Containers[0].SecurityContext == nil {
+			ret.Spec.Template.Spec.Containers[0].SecurityContext = &corev1.SecurityContext{}
+		}
+		ret.Spec.Template.Spec.Containers[0].SecurityContext.Privileged = newBool(true)
+	}
 	return ret
 }
 
-func UpdateResourceTopologyExporterCommand(args []string) []string {
-	vars := map[string]string{
-		"RTE_POLL_INTERVAL": "10s",
-	}
+func UpdateResourceTopologyExporterCommand(args []string, vars map[string]string, plat platform.Platform) []string {
 	res := []string{}
 	for _, arg := range args {
 		newArg, err := envsubst.Eval(arg, func(key string) string { return vars[key] })
@@ -35,5 +46,16 @@ func UpdateResourceTopologyExporterCommand(args []string) []string {
 		}
 		res = append(res, newArg)
 	}
+	if plat == platform.Kubernetes {
+		res = append(res, "--kubelet-config-file=/host-var/lib/kubelet/config.yaml")
+	}
+	if plat == platform.OpenShift {
+		// TODO
+		res = append(res, "--topology-manager-policy=single-numa-node")
+	}
 	return res
+}
+
+func newBool(val bool) *bool {
+	return &val
 }

--- a/pkg/manifests/yaml/rte/daemonset.yaml
+++ b/pkg/manifests/yaml/rte/daemonset.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: resource-topology-exporter-ds
+  name: resource-topology-exporter
 spec:
   selector:
       matchLabels:
@@ -17,11 +17,11 @@ spec:
         image: ${RTE_CONTAINER_IMAGE}
         command:
         - /bin/resource-topology-exporter
-        - --export-namespace=default
+        - --export-namespace=${EXPORT_NAMESPACE}
         - --sleep-interval=${RTE_POLL_INTERVAL}
         - --sysfs=/host-sys
-        - --kubelet-config-file=/host-var/lib/kubelet/config.yaml
-        - --podresources-socket=/host-var/lib/kubelet/pod-resources/kubelet.sock
+        - --kubelet-state-dir=/host-var/lib/kubelet
+        - --podresources-socket=unix:///host-var/lib/kubelet/pod-resources/kubelet.sock
         env:
         - name: NODE_NAME
           valueFrom:


### PR DESCRIPTION
OCP add quite some layers of infrastructure.
In this patch we integrate RTE as much as possible
in the existing monitoring infrastructure.

Signed-off-by: Francesco Romani <fromani@redhat.com>