### PR TITLE
manifest: add option to force the pull policy

### DIFF
--- a/pkg/commands/deploy.go
+++ b/pkg/commands/deploy.go
@@ -72,18 +72,20 @@ func NewRemoveCommand(commonOpts *CommonOptions) *cobra.Command {
 			}
 			var err error
 			err = sched.Remove(la, sched.Options{
-				Platform:       commonOpts.Platform,
-				WaitCompletion: opts.waitCompletion,
-				RTEConfigData:  commonOpts.RTEConfigData,
+				Platform:         commonOpts.Platform,
+				WaitCompletion:   opts.waitCompletion,
+				RTEConfigData:    commonOpts.RTEConfigData,
+				PullIfNotPresent: commonOpts.PullIfNotPresent,
 			})
 			if err != nil {
 				// intentionally keep going to remove as much as possible
 				log.Printf("error removing: %v", err)
 			}
 			err = rte.Remove(la, rte.Options{
-				Platform:       commonOpts.Platform,
-				WaitCompletion: opts.waitCompletion,
-				RTEConfigData:  commonOpts.RTEConfigData,
+				Platform:         commonOpts.Platform,
+				WaitCompletion:   opts.waitCompletion,
+				RTEConfigData:    commonOpts.RTEConfigData,
+				PullIfNotPresent: commonOpts.PullIfNotPresent,
 			})
 			if err != nil {
 				// intentionally keep going to remove as much as possible
@@ -136,9 +138,10 @@ func NewDeploySchedulerPluginCommand(commonOpts *CommonOptions, opts *deployOpti
 				debugLog: commonOpts.DebugLog,
 			}
 			return sched.Deploy(la, sched.Options{
-				Platform:       commonOpts.Platform,
-				WaitCompletion: opts.waitCompletion,
-				RTEConfigData:  commonOpts.RTEConfigData,
+				Platform:         commonOpts.Platform,
+				WaitCompletion:   opts.waitCompletion,
+				RTEConfigData:    commonOpts.RTEConfigData,
+				PullIfNotPresent: commonOpts.PullIfNotPresent,
 			})
 		},
 		Args: cobra.NoArgs,
@@ -156,9 +159,10 @@ func NewDeployTopologyUpdaterCommand(commonOpts *CommonOptions, opts *deployOpti
 				debugLog: commonOpts.DebugLog,
 			}
 			return rte.Deploy(la, rte.Options{
-				Platform:       commonOpts.Platform,
-				WaitCompletion: opts.waitCompletion,
-				RTEConfigData:  commonOpts.RTEConfigData,
+				Platform:         commonOpts.Platform,
+				WaitCompletion:   opts.waitCompletion,
+				RTEConfigData:    commonOpts.RTEConfigData,
+				PullIfNotPresent: commonOpts.PullIfNotPresent,
 			})
 		},
 		Args: cobra.NoArgs,
@@ -195,9 +199,10 @@ func NewRemoveSchedulerPluginCommand(commonOpts *CommonOptions, opts *deployOpti
 				debugLog: commonOpts.DebugLog,
 			}
 			return sched.Remove(la, sched.Options{
-				Platform:       commonOpts.Platform,
-				WaitCompletion: opts.waitCompletion,
-				RTEConfigData:  commonOpts.RTEConfigData,
+				Platform:         commonOpts.Platform,
+				WaitCompletion:   opts.waitCompletion,
+				RTEConfigData:    commonOpts.RTEConfigData,
+				PullIfNotPresent: commonOpts.PullIfNotPresent,
 			})
 		},
 		Args: cobra.NoArgs,
@@ -215,9 +220,10 @@ func NewRemoveTopologyUpdaterCommand(commonOpts *CommonOptions, opts *deployOpti
 				debugLog: commonOpts.DebugLog,
 			}
 			return rte.Remove(la, rte.Options{
-				Platform:       commonOpts.Platform,
-				WaitCompletion: opts.waitCompletion,
-				RTEConfigData:  commonOpts.RTEConfigData,
+				Platform:         commonOpts.Platform,
+				WaitCompletion:   opts.waitCompletion,
+				RTEConfigData:    commonOpts.RTEConfigData,
+				PullIfNotPresent: commonOpts.PullIfNotPresent,
 			})
 		},
 		Args: cobra.NoArgs,
@@ -236,16 +242,18 @@ func deployOnCluster(commonOpts *CommonOptions, opts *deployOptions) error {
 		return err
 	}
 	if err := rte.Deploy(la, rte.Options{
-		Platform:       commonOpts.Platform,
-		WaitCompletion: opts.waitCompletion,
-		RTEConfigData:  commonOpts.RTEConfigData,
+		Platform:         commonOpts.Platform,
+		WaitCompletion:   opts.waitCompletion,
+		RTEConfigData:    commonOpts.RTEConfigData,
+		PullIfNotPresent: commonOpts.PullIfNotPresent,
 	}); err != nil {
 		return err
 	}
 	if err := sched.Deploy(la, sched.Options{
-		Platform:       commonOpts.Platform,
-		WaitCompletion: opts.waitCompletion,
-		RTEConfigData:  commonOpts.RTEConfigData,
+		Platform:         commonOpts.Platform,
+		WaitCompletion:   opts.waitCompletion,
+		RTEConfigData:    commonOpts.RTEConfigData,
+		PullIfNotPresent: commonOpts.PullIfNotPresent,
 	}); err != nil {
 		return err
 	}

--- a/pkg/commands/render.go
+++ b/pkg/commands/render.go
@@ -79,6 +79,7 @@ func NewRenderSchedulerPluginCommand(commonOpts *CommonOptions, opts *renderOpti
 			updateOpts := sched.UpdateOptions{
 				Replicas:               int32(commonOpts.Replicas),
 				NodeResourcesNamespace: rteManifests.Namespace.Name,
+				PullIfNotPresent:       commonOpts.PullIfNotPresent,
 			}
 			return renderObjects(schedManifests.Update(updateOpts).ToObjects())
 		},
@@ -97,7 +98,8 @@ func NewRenderTopologyUpdaterCommand(commonOpts *CommonOptions, opts *renderOpti
 				return err
 			}
 			updateOpts := rte.UpdateOptions{
-				ConfigData: commonOpts.RTEConfigData,
+				ConfigData:       commonOpts.RTEConfigData,
+				PullIfNotPresent: commonOpts.PullIfNotPresent,
 			}
 			return renderObjects(rteManifests.Update(updateOpts).ToObjects())
 		},
@@ -120,7 +122,8 @@ func renderManifests(cmd *cobra.Command, commonOpts *CommonOptions, opts *render
 		return err
 	}
 	rteUpdateOpts := rte.UpdateOptions{
-		ConfigData: commonOpts.RTEConfigData,
+		ConfigData:       commonOpts.RTEConfigData,
+		PullIfNotPresent: commonOpts.PullIfNotPresent,
 	}
 	objs = append(objs, rteManifests.Update(rteUpdateOpts).ToObjects()...)
 
@@ -132,6 +135,7 @@ func renderManifests(cmd *cobra.Command, commonOpts *CommonOptions, opts *render
 	schedUpdateOpts := sched.UpdateOptions{
 		Replicas:               int32(commonOpts.Replicas),
 		NodeResourcesNamespace: rteManifests.Namespace.Name,
+		PullIfNotPresent:       commonOpts.PullIfNotPresent,
 	}
 	objs = append(objs, schedManifests.Update(schedUpdateOpts).ToObjects()...)
 

--- a/pkg/commands/root.go
+++ b/pkg/commands/root.go
@@ -22,19 +22,21 @@ import (
 	"log"
 	"os"
 
-	"github.com/fromanirh/deployer/pkg/deployer/platform"
 	"github.com/spf13/cobra"
+
+	"github.com/fromanirh/deployer/pkg/deployer/platform"
 )
 
 type CommonOptions struct {
-	Debug         bool
-	Platform      platform.Platform
-	Log           *log.Logger
-	DebugLog      *log.Logger
-	Replicas      int
-	RTEConfigData string
-	rteConfigFile string
-	plat          string
+	Debug            bool
+	Platform         platform.Platform
+	Log              *log.Logger
+	DebugLog         *log.Logger
+	Replicas         int
+	RTEConfigData    string
+	PullIfNotPresent bool
+	rteConfigFile    string
+	plat             string
 }
 
 func ShowHelp(cmd *cobra.Command, args []string) error {
@@ -86,6 +88,7 @@ func NewRootCommand(extraCmds ...NewCommandFunc) *cobra.Command {
 	root.PersistentFlags().BoolVarP(&commonOpts.Debug, "debug", "D", false, "enable debug log")
 	root.PersistentFlags().StringVarP(&commonOpts.plat, "platform", "P", "kubernetes", "platform to deploy on")
 	root.PersistentFlags().IntVarP(&commonOpts.Replicas, "replicas", "R", 1, "set the replica value - where relevant.")
+	root.PersistentFlags().BoolVar(&commonOpts.PullIfNotPresent, "pull-if-not-present", false, "force pull policies to IfNotPresent.")
 	root.PersistentFlags().StringVar(&commonOpts.rteConfigFile, "rte-config-file", "", "inject rte configuration reading from this file.")
 
 	root.AddCommand(

--- a/pkg/deployer/rte/rte.go
+++ b/pkg/deployer/rte/rte.go
@@ -23,9 +23,10 @@ import (
 )
 
 type Options struct {
-	Platform       platform.Platform
-	WaitCompletion bool
-	RTEConfigData  string
+	Platform         platform.Platform
+	WaitCompletion   bool
+	RTEConfigData    string
+	PullIfNotPresent bool
 }
 
 func Deploy(log deployer.Logger, opts Options) error {
@@ -36,7 +37,10 @@ func Deploy(log deployer.Logger, opts Options) error {
 	if err != nil {
 		return err
 	}
-	mf = mf.Update(rtemanifests.UpdateOptions{ConfigData: opts.RTEConfigData})
+	mf = mf.Update(rtemanifests.UpdateOptions{
+		ConfigData:       opts.RTEConfigData,
+		PullIfNotPresent: opts.PullIfNotPresent,
+	})
 	log.Debugf("RTE manifests loaded")
 
 	hp, err := deployer.NewHelper("RTE", log)
@@ -73,7 +77,10 @@ func Remove(log deployer.Logger, opts Options) error {
 	if err != nil {
 		return err
 	}
-	mf = mf.Update(rtemanifests.UpdateOptions{ConfigData: opts.RTEConfigData})
+	mf = mf.Update(rtemanifests.UpdateOptions{
+		ConfigData:       opts.RTEConfigData,
+		PullIfNotPresent: opts.PullIfNotPresent,
+	})
 	log.Debugf("RTE manifests loaded")
 
 	for _, wo := range mf.ToDeletableObjects(hp, log) {

--- a/pkg/deployer/sched/sched.go
+++ b/pkg/deployer/sched/sched.go
@@ -26,10 +26,11 @@ import (
 )
 
 type Options struct {
-	Platform       platform.Platform
-	WaitCompletion bool
-	Replicas       int32
-	RTEConfigData  string
+	Platform         platform.Platform
+	WaitCompletion   bool
+	Replicas         int32
+	RTEConfigData    string
+	PullIfNotPresent bool
 }
 
 func Deploy(log deployer.Logger, opts Options) error {
@@ -50,6 +51,7 @@ func Deploy(log deployer.Logger, opts Options) error {
 	mf = mf.Update(schedmanifests.UpdateOptions{
 		Replicas:               opts.Replicas,
 		NodeResourcesNamespace: rteMf.DaemonSet.Name,
+		PullIfNotPresent:       opts.PullIfNotPresent,
 	})
 	log.Debugf("SCD manifests loaded")
 
@@ -92,6 +94,7 @@ func Remove(log deployer.Logger, opts Options) error {
 	mf = mf.Update(schedmanifests.UpdateOptions{
 		Replicas:               opts.Replicas,
 		NodeResourcesNamespace: rteMf.DaemonSet.Namespace,
+		PullIfNotPresent:       opts.PullIfNotPresent,
 	})
 	log.Debugf("SCD manifests loaded")
 

--- a/pkg/manifests/rte/rte.go
+++ b/pkg/manifests/rte/rte.go
@@ -66,7 +66,8 @@ func (mf Manifests) Clone() Manifests {
 }
 
 type UpdateOptions struct {
-	ConfigData string
+	ConfigData       string
+	PullIfNotPresent bool
 }
 
 func (mf Manifests) Update(options UpdateOptions) Manifests {
@@ -81,7 +82,7 @@ func (mf Manifests) Update(options UpdateOptions) Manifests {
 	ret.DaemonSet.Namespace = mf.namespace
 	ret.DaemonSet.Spec.Template.Spec.ServiceAccountName = mf.serviceAccount
 	manifests.UpdateClusterRoleBinding(ret.ClusterRoleBinding, mf.serviceAccount, mf.namespace)
-	manifests.UpdateResourceTopologyExporterDaemonSet(ret.plat, ret.DaemonSet, ret.ConfigMap)
+	manifests.UpdateResourceTopologyExporterDaemonSet(ret.plat, ret.DaemonSet, ret.ConfigMap, options.PullIfNotPresent)
 	return ret
 }
 

--- a/pkg/manifests/sched/sched.go
+++ b/pkg/manifests/sched/sched.go
@@ -74,6 +74,7 @@ func (mf Manifests) Clone() Manifests {
 type UpdateOptions struct {
 	Replicas               int32
 	NodeResourcesNamespace string
+	PullIfNotPresent       bool
 }
 
 func (mf Manifests) Update(options UpdateOptions) Manifests {
@@ -85,8 +86,8 @@ func (mf Manifests) Update(options UpdateOptions) Manifests {
 	ret.DPScheduler.Spec.Replicas = newInt32(replicas)
 	ret.DPController.Spec.Replicas = newInt32(replicas)
 
-	manifests.UpdateSchedulerPluginSchedulerDeployment(ret.DPScheduler)
-	manifests.UpdateSchedulerPluginControllerDeployment(ret.DPController)
+	manifests.UpdateSchedulerPluginSchedulerDeployment(ret.DPScheduler, options.PullIfNotPresent)
+	manifests.UpdateSchedulerPluginControllerDeployment(ret.DPController, options.PullIfNotPresent)
 	if mf.plat == platform.OpenShift {
 		ret.Namespace.Name = namespaceOCP
 	}


### PR DESCRIPTION
Switch the default pull policy to `Always`, which is the best practice.
Add an option to set the pull policy as `IfNotPresent` which is still more practical in some cases, most notably in most CI environments

Signed-off-by: Francesco Romani <fromani@redhat.com>