### PR TITLE
platform: detect: run detection only if needed

### DIFF
--- a/pkg/commands/detect.go
+++ b/pkg/commands/detect.go
@@ -38,10 +38,11 @@ func NewDetectCommand(commonOpts *CommonOptions) *cobra.Command {
 		Use:   "detect",
 		Short: "detect the cluster platform (kubernetes, openshift...)",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			platDetect := detectPlatform(commonOpts.DebugLog, commonOpts.UserPlatform)
 			if opts.jsonOutput {
-				json.NewEncoder(os.Stdout).Encode(commonOpts.platDetect)
+				json.NewEncoder(os.Stdout).Encode(platDetect)
 			} else {
-				fmt.Printf("%s\n", commonOpts.platDetect.Discovered)
+				fmt.Printf("%s\n", platDetect.Discovered)
 			}
 			return nil
 		},

--- a/pkg/commands/root.go
+++ b/pkg/commands/root.go
@@ -30,7 +30,6 @@ import (
 type CommonOptions struct {
 	Debug            bool
 	UserPlatform     platform.Platform
-	Platform         platform.Platform
 	Log              *log.Logger
 	DebugLog         *log.Logger
 	Replicas         int
@@ -38,7 +37,6 @@ type CommonOptions struct {
 	PullIfNotPresent bool
 	rteConfigFile    string
 	plat             string
-	platDetect       detectionOutput
 }
 
 func ShowHelp(cmd *cobra.Command, args []string) error {
@@ -67,11 +65,6 @@ func NewRootCommand(extraCmds ...NewCommandFunc) *cobra.Command {
 
 			// if it is unknown, it's fine
 			commonOpts.UserPlatform, _ = platform.FromString(commonOpts.plat)
-			commonOpts.platDetect = detectPlatform(commonOpts.DebugLog, commonOpts.UserPlatform)
-			commonOpts.Platform = commonOpts.platDetect.Discovered
-			if commonOpts.Platform == platform.Unknown {
-				return fmt.Errorf("cannot autodetect the platform, and no platform given")
-			}
 
 			if commonOpts.rteConfigFile != "" {
 				data, err := os.ReadFile(commonOpts.rteConfigFile)

--- a/test/e2e/positive.go
+++ b/test/e2e/positive.go
@@ -49,6 +49,7 @@ var _ = ginkgo.Describe("[PositiveFlow] Deployer render", func() {
 		ginkgo.It("it should reflect the overrides in the output", func() {
 			cmdline := []string{
 				filepath.Join(binariesPath, "deployer"),
+				"-P", "kubernetes",
 				"render",
 			}
 			fmt.Fprintf(ginkgo.GinkgoWriter, "running: %v\n", cmdline)


### PR DESCRIPTION
Previously, the code was overeager to autodetect the platform,
leading to potentially confusing behaviour (e.g. wrong help text)
and in general requiring KUBECONFIG excessively.

Move later in the flows which actually need it the platform detection.

Signed-off-by: Francesco Romani <fromani@redhat.com>